### PR TITLE
feat: Update Vert.x from 4.5.15 to 5.0.0

### DIFF
--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -2,6 +2,8 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
 import org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED
 import org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
+import org.jetbrains.kotlin.gradle.dsl.jvm.JvmTargetValidationMode.IGNORE
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     application
@@ -9,9 +11,7 @@ plugins {
 }
 
 val mainVerticleName = "com.github.thorlauridsen.MainVerticle"
-val launcherClassName = "io.vertx.core.Launcher"
-
-val doOnChange = "${projectDir}/gradlew classes"
+val launcherClassName = "io.vertx.launcher.application.VertxApplication"
 
 application {
     mainClass.set(launcherClassName)
@@ -29,11 +29,11 @@ dependencies {
     implementation(local.vertx.json.schema)
     implementation(local.vertx.lang.kotlin)
     implementation(local.vertx.lang.kotlin.coroutines)
+    implementation(local.vertx.launcher)
     implementation(local.vertx.pg.client)
     implementation(local.vertx.web)
     implementation(local.vertx.web.openapi)
     implementation(local.vertx.web.validation)
-    implementation(platform(local.vertx.stack.depchain))
 
     // FasterXML Jackson databind for JSON serialization/deserialization
     implementation(local.jackson.databind)
@@ -49,17 +49,15 @@ dependencies {
     // Liquibase for database migrations
     implementation(local.liquibase.core)
 
-    // JDBC connection pool for Vert.x + PostgreSQL
-    implementation(local.agroal.pool)
-
-    // SCRAM client for authenticating PostgreSQL connections
-    implementation(local.ongres.scram.client)
-
     // Test dependencies
     testImplementation(local.vertx.junit5)
     testImplementation(local.vertx.web.client)
     testImplementation(local.junit.jupiter)
     testImplementation(local.kotlin.coroutines.test)
+}
+
+tasks.withType<KotlinJvmCompile>().configureEach {
+    jvmTargetValidationMode.set(IGNORE)
 }
 
 tasks.withType<ShadowJar> {
@@ -78,10 +76,5 @@ tasks.withType<Test> {
 }
 
 tasks.withType<JavaExec> {
-    args = listOf(
-        "run",
-        mainVerticleName,
-        "--launcher-class=$launcherClassName",
-        "--on-redeploy=$doOnChange"
-    )
+    args = listOf(mainVerticleName)
 }

--- a/apps/api/src/main/kotlin/com/github/thorlauridsen/config/DatabaseConfig.kt
+++ b/apps/api/src/main/kotlin/com/github/thorlauridsen/config/DatabaseConfig.kt
@@ -1,0 +1,80 @@
+package com.github.thorlauridsen.config
+
+import io.vertx.core.json.JsonObject
+
+/**
+ * Configuration for the database connection.
+ *
+ * @property host The hostname or IP address of the database server.
+ * @property type The type of the database, such as H2 or PostgreSQL.
+ * @property port The port number on which the database server is listening.
+ * @property name The name of the database to connect to.
+ * @property username The username for authenticating with the database.
+ * @property password The password for authenticating with the database.
+ * @property liquibaseChangelog The path to the Liquibase changelog file for database migrations.
+ */
+data class DatabaseConfig(
+    val host: String,
+    val type: DatabaseType,
+    val port: Int,
+    val name: String,
+    val username: String,
+    val password: String,
+    val liquibaseChangelog: String,
+) {
+
+    /**
+     * Checks if the database type is H2.
+     *
+     * @return true if the database type is H2, false otherwise.
+     */
+    fun isH2(): Boolean {
+        return type == DatabaseType.H2
+    }
+
+    companion object {
+
+        /**
+         * Parses the database configuration from a JSON object.
+         *
+         * @param jsonObject The JSON object containing the database configuration.
+         * @return A [DatabaseConfig] instance with the parsed configuration.
+         * @throws IllegalArgumentException if any required field is missing or null.
+         */
+        fun getConfig(jsonObject: JsonObject): DatabaseConfig {
+
+            val database = jsonObject.getJsonObject("database")
+            requireNotNull(database) { "'database' cannot be null in application.yaml" }
+
+            val host = database.getString("host")
+            val port = database.getInteger("port")
+            val name = database.getString("name")
+            val username = database.getString("username")
+            val password = database.getString("password")
+            val liquibaseChangelog = database.getJsonObject("liquibase").getString("changelog")
+
+            requireNotNull(host) { "'database.host' cannot be null in application.yaml" }
+            requireNotNull(port) { "'database.port' cannot be null in application.yaml" }
+            requireNotNull(name) { "'database.name' cannot be null in application.yaml" }
+            requireNotNull(username) { "'database.username' cannot be null in application.yaml" }
+            requireNotNull(password) { "'database.password' cannot be null in application.yaml" }
+            requireNotNull(liquibaseChangelog) { "'database.liquibase.changelog' cannot be null in application.yaml" }
+
+            val type = if (host.lowercase().contains("h2")) {
+                DatabaseType.H2
+            } else {
+                DatabaseType.Postgres
+            }
+
+            return DatabaseConfig(
+                host = host,
+                type = type,
+                port = port,
+                name = name,
+                username = username,
+                password = password,
+                liquibaseChangelog = liquibaseChangelog
+            )
+        }
+    }
+}

--- a/apps/api/src/main/kotlin/com/github/thorlauridsen/config/DatabaseInitializer.kt
+++ b/apps/api/src/main/kotlin/com/github/thorlauridsen/config/DatabaseInitializer.kt
@@ -4,18 +4,23 @@ import io.vertx.config.ConfigRetriever
 import io.vertx.config.ConfigRetrieverOptions
 import io.vertx.config.ConfigStoreOptions
 import io.vertx.core.Vertx
-import io.vertx.core.impl.logging.LoggerFactory
+import io.vertx.core.internal.logging.LoggerFactory
 import io.vertx.core.json.JsonObject
 import io.vertx.jdbcclient.JDBCConnectOptions
-import io.vertx.sqlclient.PoolOptions
 import io.vertx.jdbcclient.JDBCPool
-import liquibase.Liquibase
-import liquibase.database.jvm.JdbcConnection
-import liquibase.resource.ClassLoaderResourceAccessor
+import io.vertx.pgclient.PgBuilder
+import io.vertx.pgclient.PgConnectOptions
+import io.vertx.sqlclient.Pool
+import io.vertx.sqlclient.PoolOptions
 import java.sql.DriverManager
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import liquibase.Liquibase
+import liquibase.database.jvm.JdbcConnection
+import liquibase.resource.ClassLoaderResourceAccessor
 
 /**
  * This class is responsible for initializing the database.
@@ -28,43 +33,119 @@ class DatabaseInitializer(private val vertx: Vertx) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     /**
-     * Initialize the database.
+     * Initializes the database connection pool.
      *
-     * This method creates a connection pool and runs Liquibase migrations.
-     * It returns a [JDBCPool] instance.
+     * This method loads the database configuration from the application.yaml file,
+     * runs Liquibase migrations, and returns a configured [Pool] instance.
+     * The jdbcUrl is determined based on the database type.
+     * The jdbcUrl is required for Liquibase to run migrations.
      *
-     * @return [JDBCPool] instance.
+     * @return a [Pool] instance for the database connection.
      */
-    suspend fun initialize(): JDBCPool {
-        val config = loadConfiguration()
-        val dbConfig = config.getJsonObject("database")
+    suspend fun initialize(): Pool {
+        logger.info("Initializing database...")
 
-        val jdbcUrl = dbConfig.getString("url")
-        val username = dbConfig.getString("username")
-        val password = dbConfig.getString("password")
-        val liquibaseChangelog = dbConfig.getJsonObject("liquibase").getString("changelog")
+        val jsonConfig = loadConfiguration()
+        val database = DatabaseConfig.getConfig(jsonConfig)
 
-        logger.info("Connecting to database with url: $jdbcUrl")
-        val connection = DriverManager.getConnection(jdbcUrl, username, password)
+        val jdbcUrl = if (database.isH2()) {
+            "jdbc:h2:~/test"
+        } else {
+            "jdbc:postgresql://${database.host}:${database.port}/${database.name}"
+        }
 
-        logger.info("Running Liquibase migrations")
+        runLiquibase(jdbcUrl = jdbcUrl, database = database)
+
+        return if (database.isH2()) {
+            logger.info("Connecting to in-memory H2 database...")
+            getJdbcPool(jdbcUrl = jdbcUrl, database = database)
+
+        } else {
+            logger.info("Connecting to PostgreSQL...")
+            getPgPool(database)
+        }
+    }
+
+    /**
+     * Creates a JDBC pool for H2 or other JDBC-compatible databases.
+     *
+     * @param jdbcUrl the JDBC URL of the database.
+     * @param database the database configuration containing username and password.
+     * @return a configured [Pool] instance for JDBC.
+     */
+    private fun getJdbcPool(
+        jdbcUrl: String,
+        database: DatabaseConfig,
+    ): Pool {
+        val poolOptions = PoolOptions()
+            .setMaxSize(10)
+            .setName("database-pool")
+
+        val connectOptions = JDBCConnectOptions()
+            .setJdbcUrl(jdbcUrl)
+            .setUser(database.username)
+            .setPassword(database.password)
+
+        return JDBCPool.pool(
+            vertx,
+            connectOptions,
+            poolOptions
+        )
+    }
+
+    /**
+     * Creates a non-blocking PgPool for PostgreSQL with high concurrency settings.
+     *
+     * @param database the database configuration containing connection details.
+     * @return a configured PostgreSQL [Pool] instance.
+     */
+    private fun getPgPool(database: DatabaseConfig): Pool {
+
+        val poolOptions = PoolOptions()
+            .setMaxSize(30)
+            .setName("database-pool")
+
+        val pgConnectOptions = PgConnectOptions()
+            .setHost(database.host)
+            .setPort(database.port)
+            .setDatabase(database.name)
+            .setUser(database.username)
+            .setPassword(database.password)
+            .setCachePreparedStatements(true)
+            .setPreparedStatementCacheMaxSize(256)
+            .setPreparedStatementCacheSqlLimit(2048)
+
+        return PgBuilder
+            .pool()
+            .with(poolOptions)
+            .connectingTo(pgConnectOptions)
+            .using(vertx)
+            .build()
+    }
+
+    /**
+     * Runs Liquibase migrations in a dispatcher designed for blocking operations.
+     * Liquibase requires a blocking context to execute database migrations.
+     *
+     * @param jdbcUrl the JDBC URL of the database.
+     * @param database the database configuration containing connection details.
+     */
+    private suspend fun runLiquibase(
+        jdbcUrl: String,
+        database: DatabaseConfig,
+    ) = withContext(Dispatchers.IO) {
+
+        logger.info("Running Liquibase migrations from ${database.liquibaseChangelog}")
+        val connection = DriverManager.getConnection(jdbcUrl, database.username, database.password)
+
         val liquibase = Liquibase(
-            liquibaseChangelog,
+            database.liquibaseChangelog,
             ClassLoaderResourceAccessor(),
             JdbcConnection(connection)
         )
         liquibase.update("")
 
-        return JDBCPool.pool(
-            vertx,
-            JDBCConnectOptions()
-                .setJdbcUrl(jdbcUrl)
-                .setUser(username)
-                .setPassword(password),
-            PoolOptions()
-                .setMaxSize(16)
-                .setName("database-pool")
-        )
+        logger.info("Liquibase migrations completed")
     }
 
     /**
@@ -72,12 +153,13 @@ class DatabaseInitializer(private val vertx: Vertx) {
      *
      * This will first load the configuration from the YAML file and then override it with system properties.
      * It is important to note that the system properties must match the keys in the YAML file.
-     * For example, if the YAML file has a key "database.url", then the system property must be "database.url".
+     * For example, if the YAML file has a key "database.host", then the system property must be "database.host".
      * Vert.x will automatically convert the configuration to a JsonObject.
      *
      * @return [JsonObject] containing the configuration.
      */
     private suspend fun loadConfiguration(): JsonObject = suspendCoroutine { continuation ->
+
         val yamlStore = ConfigStoreOptions()
             .setType("file")
             .setFormat("yaml")
@@ -93,13 +175,11 @@ class DatabaseInitializer(private val vertx: Vertx) {
 
         val retriever = ConfigRetriever.create(vertx, options)
 
-        retriever.getConfig { ar ->
-            if (ar.failed()) {
-                continuation.resumeWithException(ar.cause())
-                return@getConfig
+        retriever.config
+            .onSuccess {
+                continuation.resume(it)
+            }.onFailure {
+                continuation.resumeWithException(it)
             }
-            val full = ar.result()
-            continuation.resume(full)
-        }
     }
 }

--- a/apps/api/src/main/kotlin/com/github/thorlauridsen/config/DatabaseType.kt
+++ b/apps/api/src/main/kotlin/com/github/thorlauridsen/config/DatabaseType.kt
@@ -1,0 +1,10 @@
+package com.github.thorlauridsen.config
+
+/**
+ * Enum representing the types of databases supported by the application.
+ * This is used to determine which database configuration to use.
+ */
+enum class DatabaseType {
+    H2,
+    Postgres,
+}

--- a/apps/api/src/main/kotlin/com/github/thorlauridsen/route/BaseRouter.kt
+++ b/apps/api/src/main/kotlin/com/github/thorlauridsen/route/BaseRouter.kt
@@ -3,8 +3,8 @@ package com.github.thorlauridsen.route
 import com.github.thorlauridsen.dto.ErrorDto
 import com.github.thorlauridsen.exception.DomainException
 import io.netty.handler.codec.http.HttpResponseStatus
-import io.vertx.core.impl.logging.Logger
-import io.vertx.core.impl.logging.LoggerFactory
+import io.vertx.core.internal.logging.Logger
+import io.vertx.core.internal.logging.LoggerFactory
 import io.vertx.core.json.JsonObject
 import io.vertx.ext.web.RoutingContext
 

--- a/apps/api/src/main/kotlin/com/github/thorlauridsen/service/CustomerService.kt
+++ b/apps/api/src/main/kotlin/com/github/thorlauridsen/service/CustomerService.kt
@@ -4,7 +4,7 @@ import com.github.thorlauridsen.exception.CustomerNotFoundException
 import com.github.thorlauridsen.model.Customer
 import com.github.thorlauridsen.model.CustomerInput
 import com.github.thorlauridsen.model.ICustomerRepo
-import io.vertx.core.impl.logging.LoggerFactory
+import io.vertx.core.internal.logging.LoggerFactory
 import java.util.UUID
 
 /**

--- a/apps/api/src/main/resources/application-postgres.yaml
+++ b/apps/api/src/main/resources/application-postgres.yaml
@@ -1,0 +1,8 @@
+database:
+    host: localhost
+    port: 5432
+    name: sample-db
+    username: postgres
+    password: postgres
+    liquibase:
+        changelog: db/changelog/db.changelog-master.yaml

--- a/apps/api/src/main/resources/application.yaml
+++ b/apps/api/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 database:
-  url: jdbc:h2:~/test
-  username: sa
-  password:
-  liquibase:
-    changelog: db/changelog/db.changelog-master.yaml
+    host: h2
+    port: 0
+    name: test
+    username: sa
+    password: ''
+    liquibase:
+        changelog: db/changelog/db.changelog-master.yaml

--- a/apps/api/src/test/kotlin/com/github/thorlauridsen/CustomerRouterTest.kt
+++ b/apps/api/src/test/kotlin/com/github/thorlauridsen/CustomerRouterTest.kt
@@ -35,12 +35,10 @@ class CustomerRouterTest {
         this.vertx = vertx
         client = WebClient.create(vertx, clientOptions)
 
-        vertx.deployVerticle(MainVerticle()) { ar ->
-            if (ar.succeeded()) {
-                testContext.completeNow()
-            } else {
-                testContext.failNow(ar.cause())
-            }
+        vertx.deployVerticle(MainVerticle()).onSuccess {
+            testContext.completeNow()
+        }.onFailure { ar ->
+            testContext.failNow(ar)
         }
     }
 
@@ -53,14 +51,11 @@ class CustomerRouterTest {
     fun `get customer - random id - returns not found`() {
         val id = UUID.randomUUID()
 
-        client.get("/customers/$id").send { ar ->
-            if (ar.succeeded()) {
-                val response = ar.result()
-                assertEquals(HttpResponseStatus.NOT_FOUND.code(), response.statusCode())
-
-            } else {
-                throw ar.cause()
-            }
+        client.get("/customers/$id").send().onSuccess {
+            val response = it
+            assertEquals(HttpResponseStatus.NOT_FOUND.code(), response.statusCode())
+        }.onFailure { ar ->
+            throw ar
         }
     }
 

--- a/apps/api/src/test/resources/application.yaml
+++ b/apps/api/src/test/resources/application.yaml
@@ -1,6 +1,8 @@
 database:
-  url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
-  username: sa
-  password:
-  liquibase:
-    changelog: db/changelog/db.changelog-master.yaml
+    host: h2
+    port: 0
+    name: test
+    username: sa
+    password: ''
+    liquibase:
+        changelog: db/changelog/db.changelog-master.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,9 @@ services:
             - postgres
         command: >
             java
-            -Ddatabase.url=jdbc:postgresql://postgres:5432/sample-db
+            -Ddatabase.host=postgres
+            -Ddatabase.port=5432
+            -Ddatabase.name=sample-db
             -Ddatabase.username=postgres
             -Ddatabase.password=postgres
             -jar app.jar

--- a/gradle/local.versions.toml
+++ b/gradle/local.versions.toml
@@ -1,20 +1,16 @@
 [versions]
-agroal = "2.7.1"
 coroutines = "1.10.2"
 h2database = "2.3.232"
 jackson = "2.19.0"
 junit-jupiter = "5.9.1"
 kotlin = "2.1.21"
 liquibase = "4.32.0"
-ongres-scram = "2.1"
 postgresql = "42.7.6"
 shadow-plugin = "8.1.1"
-vertx = "4.5.15"
+vertx = "5.0.0"
+vertx-openapi = "4.5.15"
 
 [libraries]
-# JDBC connection pool for Vert.x + PostgreSQL
-agroal-pool = { module = "io.agroal:agroal-pool", version.ref = "agroal" }
-
 # FasterXML Jackson dependencies for JSON serialization/deserialization and Java 8 date/time support
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
@@ -32,9 +28,6 @@ kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-te
 # Liquibase for managing database changelogs
 liquibase-core = { module = "org.liquibase:liquibase-core", version.ref = "liquibase" }
 
-# SCRAM client for authenticating PostgreSQL connections
-ongres-scram-client = { module = "com.ongres.scram:client", version.ref = "ongres-scram" }
-
 # PostgreSQL for a live database
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 
@@ -46,11 +39,11 @@ vertx-json-schema = { module = "io.vertx:vertx-json-schema", version.ref = "vert
 vertx-junit5 = { module = "io.vertx:vertx-junit5", version.ref = "vertx" }
 vertx-lang-kotlin = { module = "io.vertx:vertx-lang-kotlin", version.ref = "vertx" }
 vertx-lang-kotlin-coroutines = { module = "io.vertx:vertx-lang-kotlin-coroutines", version.ref = "vertx" }
+vertx-launcher = { module = "io.vertx:vertx-launcher-application", version.ref = "vertx" }
 vertx-pg-client = { module = "io.vertx:vertx-pg-client", version.ref = "vertx" }
-vertx-stack-depchain = { module = "io.vertx:vertx-stack-depchain", version.ref = "vertx" }
 vertx-web = { module = "io.vertx:vertx-web", version.ref = "vertx" }
 vertx-web-client = { module = "io.vertx:vertx-web-client", version.ref = "vertx" }
-vertx-web-openapi = { module = "io.vertx:vertx-web-openapi", version.ref = "vertx" }
+vertx-web-openapi = { module = "io.vertx:vertx-web-openapi", version.ref = "vertx-openapi" }
 vertx-web-validation = { module = "io.vertx:vertx-web-validation", version.ref = "vertx" }
 
 [plugins]

--- a/modules/persistence/build.gradle.kts
+++ b/modules/persistence/build.gradle.kts
@@ -3,9 +3,7 @@ dependencies {
     implementation(projects.model)
 
     // Vert.x dependencies
-    implementation(local.vertx.jdbc.client)
     implementation(local.vertx.lang.kotlin)
     implementation(local.vertx.lang.kotlin.coroutines)
     implementation(local.vertx.pg.client)
-    implementation(platform(local.vertx.stack.depchain))
 }

--- a/modules/persistence/src/main/kotlin/com/github/thorlauridsen/persistence/CustomerRepo.kt
+++ b/modules/persistence/src/main/kotlin/com/github/thorlauridsen/persistence/CustomerRepo.kt
@@ -25,7 +25,7 @@ class CustomerRepo(private val client: SqlClient) : ICustomerRepo {
     override suspend fun save(customer: CustomerInput): Customer {
         val id = UUID.randomUUID()
 
-        client.preparedQuery("INSERT INTO customer(id, mail) VALUES (?, ?)")
+        client.preparedQuery("INSERT INTO customer (id, mail) VALUES ($1, $2)")
             .execute(Tuple.of(id, customer.mail))
             .coAwait()
 
@@ -38,7 +38,7 @@ class CustomerRepo(private val client: SqlClient) : ICustomerRepo {
      * @return [Customer] or null if not found.
      */
     override suspend fun find(id: UUID): Customer? {
-        val row = client.preparedQuery("SELECT id, mail FROM customer WHERE id = ?")
+        val row = client.preparedQuery("SELECT id, mail FROM customer WHERE id = $1")
             .execute(Tuple.of(id))
             .coAwait()
             .firstOrNull()


### PR DESCRIPTION
- Update Vert.x from 4.5.15 to 5.0.0
- Remove unnecessary Gradle dependencies from `local.versions.toml`:
  - `com.ongres.scram:client`
  - `io.agroal:agroal-pool`
  - `io.vertx:vertx-stack-depchain`
- Add data class `DatabaseConfig` with the purpose of containing database connection details retrieved from the `application.yaml` file.
- Refactor `DatabaseInitializer` by making the code more structured. There are now distinct methods for running Liquibase migrations and getting the database pool depending on whether the database connection has been set to H2 or PostgreSQL.