### PR TITLE
build: Update Gradle from 8.14.3 to 9.1.0

### DIFF
--- a/gradle/local.versions.toml
+++ b/gradle/local.versions.toml
@@ -6,7 +6,7 @@ junit-jupiter = "5.9.1"
 kotlin = "2.2.20"
 liquibase = "4.33.0"
 postgresql = "42.7.7"
-shadow-plugin = "8.1.1"
+shadow-plugin = "9.1.0"
 vertx = "5.0.4"
 vertx-openapi = "4.5.21"
 
@@ -48,4 +48,4 @@ vertx-web-validation = { module = "io.vertx:vertx-web-validation", version.ref =
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow-plugin" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow-plugin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Update Gradle from 8.14.3 to 9.1.0 in gradle-wrapper.properties.
- Update plugin location from com.github.johnrengelman.shadow to com.gradleup.shadow.
- Update com.gradleup.shadow from 8.1.1 to 9.1.0